### PR TITLE
renamed colors to match file names

### DIFF
--- a/colors/mountaineer-grey.vim
+++ b/colors/mountaineer-grey.vim
@@ -152,7 +152,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "tomorrow"
+let g:colors_name = "mountaineer-grey"
 
 " Highlighting function
 " Optional variables are attributes and guisp

--- a/colors/mountaineer-light.vim
+++ b/colors/mountaineer-light.vim
@@ -152,7 +152,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "tomorrow"
+let g:colors_name = "mountaineer-light"
 
 " Highlighting function
 " Optional variables are attributes and guisp

--- a/colors/mountaineer.vim
+++ b/colors/mountaineer.vim
@@ -152,7 +152,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "tomorrow"
+let g:colors_name = "mountaineer"
 
 " Highlighting function
 " Optional variables are attributes and guisp


### PR DESCRIPTION
Hi I was having some issues with the theme name, should the theme name variables match the file names?
This is the error I see when `g:colors_name = "tomorrow"`

```
Error detected while processing /Users/rob/.vim/bundle/vim-polyglot/plugin/polyglot.vim[8]../usr/local/Cellar/vim/8.2.1900/share/vim/vim82/syntax/syntax.vim[19]../usr/local/Cellar/vim/8.2.1900/share/vim/vim82/syntax/synload.vim:
line   19:
E185: Cannot find color scheme 'tomorrow'
```
